### PR TITLE
fix: correct svelte file extension

### DIFF
--- a/utils/helper.py
+++ b/utils/helper.py
@@ -31,7 +31,7 @@ encode_kwargs = {"normalize_embeddings": False}
 model_kwargs = {"device": "cuda:0"}  
 allowed_extensions = ['.py', '.md', '.js',
                     '.html', '.css', '.ts', '.sh',
-                    '.go', '.java', 'svelte']
+                    '.go', '.java', '.svelte']
 
 # remove the directories for the download/upload projects
 def remove_directory(dir_path):


### PR DESCRIPTION
## Summary
- ensure Svelte files are recognized by file loader by adding missing dot to `.svelte` extension

## Testing
- `python -m py_compile utils/helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa8778af9083308c6e21db3670f67c